### PR TITLE
feat: Add PB2 DMS CSV ingestion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+.DS_Store

--- a/DB/inserts/file_parsers/dms_parser.py
+++ b/DB/inserts/file_parsers/dms_parser.py
@@ -194,5 +194,5 @@ class Pb2RegionDmsCsvParser(DmsFileParser):
     }
 
     data_column_name_map = {
-        'mutdiffsel': 'mutdiffsel'
+        StandardPhenoMetricNames.mutdiffsel: 'mutdiffsel'
     }

--- a/DB/inserts/file_parsers/dms_parser.py
+++ b/DB/inserts/file_parsers/dms_parser.py
@@ -178,6 +178,7 @@ class HaRegionDmsCsvParserNewData(DmsFileParser):
         StandardPhenoMetricNames.entry_in_sa26_and_sa23_293t_cells: 'entry in SA26 and SA23 293T cells',
     }
 
+
 class Pb2RegionDmsCsvParser(DmsFileParser):
     """Parser for DMS data for Influenza PB2 region"""
     def __init__(self, filename: str):

--- a/DB/inserts/file_parsers/dms_parser.py
+++ b/DB/inserts/file_parsers/dms_parser.py
@@ -177,3 +177,21 @@ class HaRegionDmsCsvParserNewData(DmsFileParser):
         'sa26_usage_increase_new': 'SA26 usage increase',
         StandardPhenoMetricNames.entry_in_sa26_and_sa23_293t_cells: 'entry in SA26 and SA23 293T cells',
     }
+
+class Pb2RegionDmsCsvParser(DmsFileParser):
+    """Parser for DMS data for Influenza PB2 region"""
+    def __init__(self, filename: str):
+        super().__init__(filename, ',', DefaultGffFeaturesByRegion.PB2)
+
+    async def parse_and_insert(self):
+        await super().parse_and_insert()
+
+    required_column_name_map = {
+        StandardColumnNames.position_aa: 'site',
+        StandardColumnNames.ref_aa: 'wildtype',
+        StandardColumnNames.alt_aa: 'mutation',
+    }
+
+    data_column_name_map = {
+        'mutdiffsel': 'mutdiffsel'
+    }

--- a/containers/server/bin/muninn_ingest_all
+++ b/containers/server/bin/muninn_ingest_all
@@ -68,6 +68,7 @@ MUTATIONS_FILE="$ARCHIVE_DEST_SUBDIR/mutations/mutations.tsv"
 # look in Bjorn general, default to external
 GENOFLU_FILE="genoflu_results.tsv"
 HA_DMS_FILE="$DATA_DIR/dms_HA.tsv"
+PB2_DMS_FILE="$DATA_DIR/dms_PB2.csv"
 
 # If in auto mode, find bjorn-general input files
 if [[ $AUTO = true ]]; then
@@ -96,8 +97,14 @@ if [[ $AUTO = true ]]; then
     HA_DMS_FILE="$TMP_FILE"
     echo "using HA DMS file: $HA_DMS_FILE" >> "$LOG"
   fi
+  # PB2 DMS File
+  TMP_FILE=$(find "$ARCHIVE_DEST_DIR" -type f -name "dms_PB2*.csv" | head -1)
+  if [[ -f "$TMP_FILE" ]]; then
+      PB2_DMS_FILE="$TMP_FILE"
+    echo "using PB2 DMS file: $PB2_DMS_FILE" >> "$LOG" fi
+  fi
 
-  TMP_FILE=$(find "$ARCHIVE_DEST_DIR" -type f -name "*genoflu_results*.tsv" | head -1)
+ TMP_FILE=$(find "$ARCHIVE_DEST_DIR" -type f -name "*genoflu_results*.tsv" | head -1)
   if [[ -f "$TMP_FILE" ]]; then
     GENOFLU_FILE="$TMP_FILE"
     echo "using genoflu results file: $GENOFLU_FILE" >> "$LOG"
@@ -123,6 +130,7 @@ ALLELE_REF_CONFLICTS_FILE="/tmp/allele_ref_conflicts.csv"
   --format variants_mutations_combined_tsv
   python3 -u runinserts.py "$HA_DMS_FILE" --format ha_dms_tsv
   python3 -u runinserts.py "$GENOFLU_FILE" --format genoflu_lineages
+  python3 -u runinserts.py "$PB2_DMS_FILE"  --format pb2_dms_csv
 
   # ingest random other outputs
   python3 -u runinserts.py "$DATA_DIR/$EVE_FILE" --format eve_dms_csv

--- a/containers/server/bin/muninn_ingest_all
+++ b/containers/server/bin/muninn_ingest_all
@@ -100,11 +100,11 @@ if [[ $AUTO = true ]]; then
   # PB2 DMS File
   TMP_FILE=$(find "$ARCHIVE_DEST_DIR" -type f -name "dms_PB2*.csv" | head -1)
   if [[ -f "$TMP_FILE" ]]; then
-      PB2_DMS_FILE="$TMP_FILE"
-    echo "using PB2 DMS file: $PB2_DMS_FILE" >> "$LOG" fi
+    PB2_DMS_FILE="$TMP_FILE"
+    echo "using PB2 DMS file: $PB2_DMS_FILE" >> "$LOG"
   fi
 
- TMP_FILE=$(find "$ARCHIVE_DEST_DIR" -type f -name "*genoflu_results*.tsv" | head -1)
+  TMP_FILE=$(find "$ARCHIVE_DEST_DIR" -type f -name "*genoflu_results*.tsv" | head -1)
   if [[ -f "$TMP_FILE" ]]; then
     GENOFLU_FILE="$TMP_FILE"
     echo "using genoflu results file: $GENOFLU_FILE" >> "$LOG"

--- a/containers/server/bin/muninn_ingest_all
+++ b/containers/server/bin/muninn_ingest_all
@@ -130,7 +130,7 @@ ALLELE_REF_CONFLICTS_FILE="/tmp/allele_ref_conflicts.csv"
   --format variants_mutations_combined_tsv
   python3 -u runinserts.py "$HA_DMS_FILE" --format ha_dms_tsv
   python3 -u runinserts.py "$GENOFLU_FILE" --format genoflu_lineages
-  python3 -u runinserts.py "$PB2_DMS_FILE"  --format pb2_dms_csv
+  python3 -u runinserts.py "$PB2_DMS_FILE" --format pb2_dms_csv
 
   # ingest random other outputs
   python3 -u runinserts.py "$DATA_DIR/$EVE_FILE" --format eve_dms_csv

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Database system to store mutation and variant data for avian influenza.
    
     export MUNINN_SERVER_PORT="8000"
     
-    # this will be mounted to the server container as /flu/data
+    # this will be mounted to the server container as /home/muninn/data
     export MUNINN_SERVER_DATA_INPUT_DIR="/dev/null"
     
     # this controls which config file is applied to postgres
@@ -30,7 +30,7 @@ Database system to store mutation and variant data for avian influenza.
     # this will be used as a prefix to the container names
     export MUNINN_INSTANCE_NAME="flu_db"
     ```
-    - Change the value for `MUNINN_DB_SERVER_DATA_INPUT_DIR` to allow the server to read input data from a host directory.
+    - Change the value for `MUNINN_SERVER_DATA_INPUT_DIR` to allow the server to read input data from a host directory.
     - If the server and DB are running on the same host, they will talk through the docker network. 
     In that case, `MUNINN_DB_PORT_FOR_SERVER` should be 5432, regardless of the value of `MUNINN_DB_PORT`, 
     and `MUNINN_DB_HOST` should be `"postgres"`, which is the name of the database service within docker.
@@ -42,14 +42,14 @@ Database system to store mutation and variant data for avian influenza.
     4. Use `docker logs flu_db_server` to see server logs.
 4. Update the database schema: `docker exec -d flu_db_server muninn_schema_update`
 5. Load or update data:  `docker exec -d flu_db_server muninn_ingest_all --auto --archive_in <name of archive>`
-    1. Input data must be placed in `MUNINN_DB_SERVER_DATA_INPUT_DIR` on the host machine, in either `.zip` or `.tar.gz` format.
+    1. Input data must be placed in `MUNINN_SERVER_DATA_INPUT_DIR` on the host machine, in either `.zip` or `.tar.gz` format.
            For details read ingestion script: `containers/server/bin/muninn_ingest_all`
     2. This process will take 15-45 minutes to finish, but existing records will be updated in-place, and the webserver
        will remain available.
     3. For information on logs see Troubleshooting Information > Webserver
     4. The `--auto` flag is optional, but this mode avoids the need to adhere to specific file and dir names within the input archive.
-6. Load or update test data: `docker exec -d flu_db_server muninn_ingest_playset ${MUNINN_DB_SERVER_DATA_INPUT_DIR}/<archive name>`
-    1. Input data must be placed in `MUNINN_DB_SERVER_DATA_INPUT_DIR` on the host machine.
+6. Load or update test data: `docker exec -d flu_db_server muninn_ingest_playset ${MUNINN_SERVER_DATA_INPUT_DIR}/<archive name>`
+    1. Input data must be placed in `MUNINN_SERVER_DATA_INPUT_DIR` on the host machine.
        For details read ingestion script: `containers/server/bin/muninn_ingest_playset`
     2. This process will take a few minutes and data will persist in a docker volume. Please see `docker-compose.yml` for details.
     3. For information on logs see Troubleshooting Information > Webserver

--- a/runinserts.py
+++ b/runinserts.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any
 
 from DB.inserts.file_parsers.flumut_annotations_parser import FlumutTsvParser
-from DB.inserts.file_parsers.dms_parser import HaRegionDmsTsvParser, HaRegionDmsCsvParser, HaRegionDmsCsvParserNewData
+from DB.inserts.file_parsers.dms_parser import HaRegionDmsTsvParser, HaRegionDmsCsvParser, HaRegionDmsCsvParserNewData, Pb2RegionDmsCsvParser
 from DB.inserts.file_parsers.eve_parser import EveCsvParser
 from DB.inserts.file_parsers.file_parser import FileParser
 from DB.inserts.file_parsers.freyja_demixed_lineage_hierarchy_parser import FreyjaDemixedLineageHierarchyYamlParser
@@ -25,6 +25,7 @@ def main():
         'genoflu_lineages': GenofluLineagesParser,
         'ha_dms_tsv': HaRegionDmsTsvParser,
         'ha_dms_csv': HaRegionDmsCsvParser,
+        'pb2_dms_csv': Pb2RegionDmsCsvParser,
         'freyja_demixed': FreyjaDemixedParser,
         'variants_mutations_combined_tsv': VariantsMutationsCombinedParser,
         'sc2_samples': SC2SamplesParser,

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -42,6 +42,7 @@ class PhenotypeMetricAssayTypes:
 
 class DefaultGffFeaturesByRegion:
     HA = 'XAJ25415.1'
+    PB2 = 'XAJ25426.1'
 
 
 class LineageSystemNames:

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -221,6 +221,7 @@ class StandardPhenoMetricNames:
     ferret_sera_escape = 'ferret_sera_escape'
     mouse_sera_escape = 'mouse_sera_escape'
     entry_in_sa26_and_sa23_293t_cells = 'entry_in_sa26_and_sa23_293t_cells'
+    mutdiffsel = 'mutdiffsel'
 
 
 class ConstraintNames:


### PR DESCRIPTION
This pull request introduces support for parsing DMS (Deep Mutational Scanning) data for the Influenza PB2 region.

### PB2 Region DMS Data Support

* Added the `Pb2RegionDmsCsvParser` class to `dms_parser.py` for parsing DMS data specific to the Influenza PB2 region, including required and data column mappings.
* Updated `utils/constants.py` to include the PB2 region identifier in `DefaultGffFeaturesByRegion`.

### Data Ingestion Runner Updates

* Registered the new `Pb2RegionDmsCsvParser` in the `runinserts.py` ingestion runner, allowing selection via the `'pb2_dms_csv'` key. [[1]](diffhunk://#diff-0d68162bfe5dc7cda69797aba1e662a3af91ccf949d12b310394b87c4d1f00e7L8-R8) [[2]](diffhunk://#diff-0d68162bfe5dc7cda69797aba1e662a3af91ccf949d12b310394b87c4d1f00e7R28)

### Documentation Consistency

* Updated environment variable references and usage instructions in `readme.md` to consistently use `MUNINN_SERVER_DATA_INPUT_DIR` instead of the outdated `MUNINN_DB_SERVER_DATA_INPUT_DIR`, and clarified the mount path for input data. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L24-R24) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L33-R33) [[3]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L45-R52)